### PR TITLE
Fix invalid package name in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ SQLAlchemy==2.0.37
 threadpoolctl==3.5.0
 typing_extensions==4.12.2
 Werkzeug==3.1.3
-pytorch==2.5.1
+torch==2.5.1
 torchvision==0.20.1
 Pillow==11.1.0
 Brotli==1.0.9


### PR DESCRIPTION
## Summary
- fix the PyTorch package name in `requirements.txt`

## Testing
- `bash pre-commit` *(fails: `flake8: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683f4f32af94832c84a69a0f85e845d8