### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY web_service/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt
+COPY . .
+ENV FLASK_APP=web_service/run.py
+ENV PYTHONUNBUFFERED=1
+EXPOSE 5001
+CMD ["flask", "run", "--host=0.0.0.0", "--port=5001"]

--- a/README.MD
+++ b/README.MD
@@ -67,6 +67,7 @@ Easily create and deploy predictive models for structured data. This section ena
 *   **Configuration:** `.env` file setup (Yandex Cloud credentials, etc.)
 > ⚠️ **IMPORTANT:** You need to get access to Yandex DataSphere for the application to work. Without this access, model training will not be possible!
 *   **Running the App:** `flask run`
+*   **Docker:** `docker build -t interactive-ai-builder .` then `docker run -p 5001:5001 interactive-ai-builder`
 
 ## 📬 Contacts
 


### PR DESCRIPTION
## Summary
- add Dockerfile for deploying the Flask service
- document container build and run commands

## Testing
- `bash pre-commit` *(fails: flake8 not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6844200167f0832c9bb17c1e6ebccce6